### PR TITLE
Unvault descriptor generalisation and a threshold for fund managers

### DIFF
--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -848,6 +848,7 @@ mod tests {
         let unvault_descriptor = unvault_descriptor(
             stakeholders.clone(),
             managers.clone(),
+            managers.len(),
             cosigners.clone(),
             CSV_VALUE,
         )


### PR DESCRIPTION
This moves our unvault descriptor logic to no longer reason about assumed stakeholders that are either
or not fund managers, but instead about stakeholders and fund managers as different set of keys.

This allows us to support:
- (obviously) non-stakeholders fund managers (think employees or such).
- custom threshold set of fund managers.