### PR TITLE
Fee computation at transaction creation time

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use std::{error, fmt};
 pub enum Error {
     /// The script creation failed.
     ScriptCreation(String),
+    /// The transaction creation failed.
+    TransactionCreation(String),
     /// Satisfaction (PSBT signer role) of a Revault transaction input failed.
     InputSatisfaction(String),
     /// Completion (PSBT finalizer role) of the Revault transaction has failed.
@@ -17,6 +19,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::ScriptCreation(ref e) => write!(f, "Revault script creation error: {}", e),
+            Error::TransactionCreation(ref e) => {
+                write!(f, "Revault transaction creation error: {}", e)
+            }
             Error::InputSatisfaction(ref e) => write!(f, "Revault input satisfaction error: {}", e),
             Error::TransactionVerification(ref e) => {
                 write!(f, "Revault transaction verification error: {}", e)

--- a/src/txins.rs
+++ b/src/txins.rs
@@ -2,7 +2,7 @@
 //! Wrappers around bitcoin's OutPoint and previous TxOut to statically check Revault transaction
 //! creation and ease PSBT management.
 
-use crate::txouts::{CpfpTxOut, FeeBumpTxOut, UnvaultTxOut, VaultTxOut};
+use crate::txouts::{CpfpTxOut, FeeBumpTxOut, RevaultTxOut, UnvaultTxOut, VaultTxOut};
 
 use miniscript::bitcoin::{OutPoint, TxIn};
 
@@ -71,6 +71,21 @@ impl VaultTxIn {
             sequence: RBF_SEQUENCE,
         }
     }
+
+    /// Get the maximum size, in weight units, a satisfaction for this input would cost.
+    pub fn max_sat_weight(&self) -> usize {
+        miniscript::Descriptor::Wsh(
+            miniscript::Miniscript::parse(
+                self.prev_txout
+                    .witness_script()
+                    .as_ref()
+                    .expect("VaultTxOut has a witness_script"),
+            )
+            .expect("VaultTxIn witness_script is created from a Miniscript"),
+        )
+        .max_satisfaction_weight(miniscript::NullCtx)
+        .expect("It's a sane Script, derived from a Miniscript")
+    }
 }
 
 implem_revault_txin!(
@@ -87,6 +102,21 @@ impl UnvaultTxIn {
             prev_txout,
             sequence,
         }
+    }
+
+    /// Get the maximum size, in weight units, a satisfaction for this input would cost.
+    pub fn max_sat_weight(&self) -> usize {
+        miniscript::Descriptor::Wsh(
+            miniscript::Miniscript::parse(
+                self.prev_txout
+                    .witness_script()
+                    .as_ref()
+                    .expect("UnvaultTxOut has a witness_script"),
+            )
+            .expect("UnvaultTxIn witness_script is created from a Miniscript"),
+        )
+        .max_satisfaction_weight(miniscript::NullCtx)
+        .expect("It's a sane Script, derived from a Miniscript")
     }
 }
 

--- a/src/txouts.rs
+++ b/src/txouts.rs
@@ -2,7 +2,7 @@
 //! Wrappers around bitcoin's TxOut to statically check Revault transactions creation and ease
 //! their PSBT management.
 
-use crate::scripts::{CpfpDescriptor, UnvaultDescriptor, VaultDescriptor};
+use crate::scripts::{CpfpDescriptor, EmergencyAddress, UnvaultDescriptor, VaultDescriptor};
 
 use miniscript::{
     bitcoin::{Script, TxOut},
@@ -97,9 +97,12 @@ implem_revault_txout!(
 );
 impl EmergencyTxOut {
     /// Create a new EmergencyTxOut, note that we don't know the witness_script!
-    pub fn new(txout: TxOut) -> EmergencyTxOut {
+    pub fn new(address: EmergencyAddress, value: u64) -> EmergencyTxOut {
         EmergencyTxOut {
-            txout,
+            txout: TxOut {
+                script_pubkey: address.address().script_pubkey(),
+                value,
+            },
             witness_script: None,
         }
     }


### PR DESCRIPTION
Now that we've settled on the actual feerate of transactions and CPFP outputs values in practical-revault, this implements it at transaction-creation time.

Computing the feerate at transaction creation time allows to ~~not encounter~~ make it far less likely to encounter sneaky invalid-signature bugs because of slight divergence in fee computation in applications.
For the spend transaction, it also makes the CPFP output completely deterministic for the watchtowers: if the managers' signature is invalid, they tried to cheat on the value transferred to their fee wallet.

We also tend to have a more consistent API. Some invariant values still need to be held by callers (unvault CSV value, descriptors, locktime, key derivation context, ..) but they are now the same all along the public functions and we have far less TxOuts and TxIns moving around.

Finally, this implements some helpers functions which i believe will be helpful really soon :).

This definitely deserves some more testing.

Fixes https://github.com/re-vault/revault_tx/issues/36 .